### PR TITLE
spawn_browser: add browser_args + timezone_id

### DIFF
--- a/src/browser_manager.py
+++ b/src/browser_manager.py
@@ -1,11 +1,9 @@
 """Browser instance management with nodriver."""
 
 import asyncio
-import os
 import sys
-import time
 import uuid
-from typing import Any, Callable, Dict, Optional, List
+from typing import Any, Dict, Optional, List
 from datetime import datetime, timedelta
 
 import nodriver as uc
@@ -17,6 +15,7 @@ from persistent_storage import persistent_storage
 from dynamic_hook_system import dynamic_hook_system
 from platform_utils import get_platform_info, check_browser_executable, merge_browser_args
 from process_cleanup import process_cleanup
+from proxy_forwarder import AuthenticatedProxyForwarder
 from proxy_utils import (
     ProxyConfig,
     ProxyConfigError,
@@ -32,12 +31,12 @@ class BrowserManager:
     def __init__(self):
         self._instances: Dict[str, dict] = {}
         self._lock = asyncio.Lock()
-        self._spawn_env_lock = asyncio.Lock()
         self._spawn_diagnostics: Dict[str, Dict[str, Any]] = {}
-        self._proxy_auth_handlers: Dict[str, Dict[str, Any]] = {}
+        self._proxy_forwarders: Dict[str, AuthenticatedProxyForwarder] = {}
 
     @staticmethod
     def _append_user_agent_arg(args: List[str], user_agent: Optional[str]) -> List[str]:
+        """Merge a user agent override into launch arguments."""
         if not user_agent:
             return args
         ua_prefix = "--user-agent="
@@ -50,142 +49,53 @@ class BrowserManager:
         *,
         launch_args: List[str],
         proxy_server: Optional[str],
+        launch_proxy_server: Optional[str],
         timezone_id: Optional[str],
         sandbox: bool,
         headless: bool,
         user_data_dir: Optional[str],
     ) -> Dict[str, Any]:
+        """Build redacted diagnostics for a spawned browser instance."""
         return {
             "effective_browser_args": [redact_launch_arg(arg) for arg in launch_args],
             "proxy_server": proxy_server,
+            "launch_proxy_server": launch_proxy_server,
             "timezone_id": timezone_id,
             "sandbox": sandbox,
             "headless": headless,
             "user_data_dir": user_data_dir,
         }
 
-    async def _start_browser_with_timezone(
-        self,
+    @staticmethod
+    async def _apply_timezone_override(
         *,
-        config: uc.Config,
+        tab: Tab,
         timezone_id: Optional[str],
-    ) -> Browser:
+    ) -> Optional[str]:
+        """Apply a CDP timezone override to a browser tab."""
         if not timezone_id:
-            return await uc.start(config=config)
+            return None
 
         trimmed_timezone = timezone_id.strip()
         if not trimmed_timezone:
-            return await uc.start(config=config)
+            return None
 
-        async with self._spawn_env_lock:
-            previous_tz = os.environ.get("TZ")
-            try:
-                os.environ["TZ"] = trimmed_timezone
-                if hasattr(time, "tzset"):
-                    time.tzset()
-                return await uc.start(config=config)
-            finally:
-                if previous_tz is None:
-                    os.environ.pop("TZ", None)
-                else:
-                    os.environ["TZ"] = previous_tz
-                if hasattr(time, "tzset"):
-                    time.tzset()
+        await tab.send(uc.cdp.emulation.set_timezone_override(timezone_id=trimmed_timezone))
+        return trimmed_timezone
 
-    async def _setup_proxy_auth(
-        self,
-        *,
-        tab: Tab,
-        instance_id: str,
-        proxy_config: Optional[ProxyConfig],
-        install_request_paused_handler: bool = False,
-    ) -> None:
-        if not proxy_config or not proxy_config.username:
+    @staticmethod
+    async def _stop_browser(browser: Browser) -> None:
+        """Stop a nodriver browser regardless of sync or async stop semantics."""
+        stop_result = browser.stop()
+        if asyncio.iscoroutine(stop_result):
+            await stop_result
+
+    async def _close_proxy_forwarder(self, instance_id: str) -> None:
+        """Close and forget any authenticated proxy forwarder for an instance."""
+        proxy_forwarder = self._proxy_forwarders.pop(instance_id, None)
+        if proxy_forwarder is None:
             return
-
-        if proxy_config.password is None:
-            return
-
-        async def on_auth_required(event):
-            source = (
-                getattr(getattr(event, "auth_challenge", None), "source", None) or ""
-            ).lower()
-            response = uc.cdp.fetch.AuthChallengeResponse(response="Default")
-            if source == "proxy":
-                response = uc.cdp.fetch.AuthChallengeResponse(
-                    response="ProvideCredentials",
-                    username=proxy_config.username,
-                    password=proxy_config.password,
-                )
-            await tab.send(
-                uc.cdp.fetch.continue_with_auth(
-                    request_id=event.request_id,
-                    auth_challenge_response=response,
-                )
-            )
-
-        auth_required_handler: Callable = lambda event: asyncio.create_task(
-            on_auth_required(event)
-        )
-
-        request_paused_handler: Optional[Callable] = None
-        if install_request_paused_handler:
-
-            async def on_request_paused(event):
-                await tab.send(
-                    uc.cdp.fetch.continue_request(request_id=event.request_id)
-                )
-
-            request_paused_handler = lambda event: asyncio.create_task(
-                on_request_paused(event)
-            )
-
-        await tab.send(
-            uc.cdp.fetch.enable(
-                patterns=[
-                    uc.cdp.fetch.RequestPattern(
-                        url_pattern="*",
-                        request_stage=uc.cdp.fetch.RequestStage.REQUEST,
-                    ),
-                    uc.cdp.fetch.RequestPattern(
-                        url_pattern="*",
-                        request_stage=uc.cdp.fetch.RequestStage.RESPONSE,
-                    ),
-                ],
-                handle_auth_requests=True,
-            )
-        )
-        tab.add_handler(uc.cdp.fetch.AuthRequired, auth_required_handler)
-        if request_paused_handler:
-            tab.add_handler(uc.cdp.fetch.RequestPaused, request_paused_handler)
-        self._proxy_auth_handlers[instance_id] = {
-            "tab": tab,
-            "auth_required_handler": auth_required_handler,
-            "request_paused_handler": request_paused_handler,
-        }
-
-    async def _teardown_proxy_auth(self, instance_id: str) -> None:
-        handler_state = self._proxy_auth_handlers.pop(instance_id, None)
-        if not handler_state:
-            return
-
-        tab: Optional[Tab] = handler_state.get("tab")
-        if not tab:
-            return
-
-        auth_required_handler = handler_state.get("auth_required_handler")
-        if auth_required_handler:
-            try:
-                tab.remove_handler(uc.cdp.fetch.AuthRequired, auth_required_handler)
-            except Exception:
-                pass
-
-        request_paused_handler = handler_state.get("request_paused_handler")
-        if request_paused_handler:
-            try:
-                tab.remove_handler(uc.cdp.fetch.RequestPaused, request_paused_handler)
-            except Exception:
-                pass
+        await proxy_forwarder.close()
 
     async def spawn_browser(self, options: BrowserOptions) -> BrowserInstance:
         """
@@ -206,14 +116,23 @@ class BrowserManager:
             viewport={"width": options.viewport_width, "height": options.viewport_height}
         )
 
+        browser: Optional[Browser] = None
+        proxy_forwarder: Optional[AuthenticatedProxyForwarder] = None
         try:
             platform_info = get_platform_info()
             proxy_config: Optional[ProxyConfig] = None
+            launch_proxy_server: Optional[str] = None
             if options.proxy:
                 try:
                     proxy_config = parse_proxy_config(options.proxy)
                 except ProxyConfigError as error:
                     raise Exception(str(error))
+                if proxy_config.username is not None:
+                    proxy_forwarder = AuthenticatedProxyForwarder(options.proxy)
+                    await proxy_forwarder.start()
+                    launch_proxy_server = proxy_forwarder.proxy_server
+                else:
+                    launch_proxy_server = proxy_config.server
             
             # Detect the best available browser executable (Chrome, Chromium, or Edge)
             browser_executable = check_browser_executable()
@@ -239,7 +158,7 @@ class BrowserManager:
             caller_args = self._append_user_agent_arg(caller_args, options.user_agent)
             caller_args = merge_proxy_server_arg(
                 caller_args,
-                proxy_config.server if proxy_config else None,
+                launch_proxy_server,
             )
             launch_args = merge_browser_args(caller_args)
             
@@ -251,10 +170,7 @@ class BrowserManager:
                 browser_args=launch_args
             )
 
-            browser = await self._start_browser_with_timezone(
-                config=config,
-                timezone_id=options.timezone_id,
-            )
+            browser = await uc.start(config=config)
             tab = browser.main_tab
 
             if hasattr(browser, '_process') and browser._process:
@@ -276,23 +192,25 @@ class BrowserManager:
             )
             print(f"[DEBUG] Set viewport to {options.viewport_width}x{options.viewport_height}", file=sys.stderr)
 
-            dynamic_hooks_ok = await self._setup_dynamic_hooks(tab, instance_id)
-            await self._setup_proxy_auth(
+            applied_timezone_id = await self._apply_timezone_override(
                 tab=tab,
-                instance_id=instance_id,
-                proxy_config=proxy_config,
-                install_request_paused_handler=not dynamic_hooks_ok,
+                timezone_id=options.timezone_id,
             )
+
+            await self._setup_dynamic_hooks(tab, instance_id)
 
             spawn_diagnostics = self._build_spawn_diagnostics(
                 launch_args=launch_args,
                 proxy_server=proxy_config.server if proxy_config else None,
-                timezone_id=options.timezone_id,
+                launch_proxy_server=launch_proxy_server,
+                timezone_id=applied_timezone_id,
                 sandbox=options.sandbox,
                 headless=options.headless,
                 user_data_dir=options.user_data_dir,
             )
             self._spawn_diagnostics[instance_id] = spawn_diagnostics
+            if proxy_forwarder is not None:
+                self._proxy_forwarders[instance_id] = proxy_forwarder
 
             async with self._lock:
                 self._instances[instance_id] = {
@@ -315,6 +233,20 @@ class BrowserManager:
             })
 
         except Exception as e:
+            if browser is not None:
+                try:
+                    await self._stop_browser(browser)
+                except Exception:
+                    pass
+            if proxy_forwarder is not None:
+                try:
+                    await proxy_forwarder.close()
+                except Exception:
+                    pass
+            try:
+                process_cleanup.kill_browser_process(instance_id)
+            except Exception:
+                pass
             instance.state = BrowserState.ERROR
             raise Exception(f"Failed to spawn browser: {str(e)}")
 
@@ -386,12 +318,6 @@ class BrowserManager:
                 data = self._instances[instance_id]
                 browser = data['browser']
                 instance = data['instance']
-                tab = data.get('tab')
-
-                try:
-                    await self._teardown_proxy_auth(instance_id)
-                except Exception:
-                    pass
 
                 try:
                     if hasattr(browser, 'tabs') and browser.tabs:
@@ -435,7 +361,12 @@ class BrowserManager:
                                            f"Process cleanup failed for {instance_id}: {e}")
 
                 try:
-                    await browser.stop()
+                    await self._stop_browser(browser)
+                except Exception:
+                    pass
+
+                try:
+                    await self._close_proxy_forwarder(instance_id)
                 except Exception:
                     pass
 
@@ -493,7 +424,9 @@ class BrowserManager:
                         data['instance'].state = BrowserState.CLOSED
                         del self._instances[instance_id]
                         self._spawn_diagnostics.pop(instance_id, None)
-                        self._proxy_auth_handlers.pop(instance_id, None)
+                        proxy_forwarder = self._proxy_forwarders.pop(instance_id, None)
+                        if proxy_forwarder is not None:
+                            asyncio.create_task(proxy_forwarder.close())
                         persistent_storage.remove_instance(instance_id)
             except Exception:
                 pass

--- a/src/models.py
+++ b/src/models.py
@@ -90,7 +90,7 @@ class BrowserOptions(BaseModel):
     viewport_height: int = Field(default=1080, description="Viewport height in pixels")
     proxy: Optional[str] = Field(default=None, description="Proxy server URL")
     browser_args: List[str] = Field(default_factory=list, description="Additional browser launch arguments")
-    timezone_id: Optional[str] = Field(default=None, description="IANA timezone ID applied via TZ for browser spawn")
+    timezone_id: Optional[str] = Field(default=None, description="IANA timezone ID applied via CDP Emulation.setTimezoneOverride")
     block_resources: List[str] = Field(default_factory=list, description="Resource types to block")
     extra_headers: Dict[str, str] = Field(default_factory=dict, description="Extra HTTP headers")
     user_data_dir: Optional[str] = Field(default=None, description="Path to user data directory")

--- a/src/proxy_forwarder.py
+++ b/src/proxy_forwarder.py
@@ -1,0 +1,439 @@
+"""Authenticated proxy forwarding for browser launch proxies."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import socket
+import ssl
+from ssl import SSLContext
+from struct import calcsize, error as struct_error, pack, unpack
+from typing import Optional
+from urllib.parse import urlparse
+
+from debug_logger import debug_logger
+
+
+def _free_port() -> int:
+    """Return a free loopback TCP port for the local proxy listener."""
+    free_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    free_socket.bind(("127.0.0.1", 0))
+    free_socket.listen(5)
+    port = free_socket.getsockname()[1]
+    free_socket.close()
+    return port
+
+
+class AuthenticatedProxyForwarder:
+    """Forward local unauthenticated proxy traffic to an authenticated upstream proxy."""
+
+    def __init__(
+        self,
+        proxy_server: str,
+        ssl_context: Optional[SSLContext] = None,
+    ) -> None:
+        """
+        Initialize an authenticated proxy forwarder.
+
+        Args:
+            proxy_server (str): Upstream proxy URL with credentials.
+            ssl_context (Optional[SSLContext]): SSL context for HTTPS upstream proxies.
+        """
+        raw_value = proxy_server.strip()
+        normalized_value = (
+            raw_value if "://" in raw_value else f"http://{raw_value}"
+        )
+        parsed = urlparse(normalized_value)
+
+        if not parsed.scheme:
+            raise ValueError("Proxy URL is missing a scheme")
+        if not parsed.hostname:
+            raise ValueError("Proxy URL is missing a hostname")
+        if parsed.port is None:
+            raise ValueError("Proxy URL is missing a port")
+        if parsed.username is None or parsed.password is None:
+            raise ValueError("Proxy URL must include both username and password")
+
+        self.server: Optional[asyncio.AbstractServer] = None
+        self.ssl_context = ssl_context
+        self.scheme = parsed.scheme
+        self.use_ssl = parsed.scheme == "https"
+        self.username = parsed.username
+        self.password = parsed.password
+        self.fw_host = parsed.hostname
+        self.fw_port = parsed.port
+        self.host = "127.0.0.1"
+        self.port = _free_port()
+
+        if self.scheme.startswith("http"):
+            self._proxy_server = f"http://{self.host}:{self.port}"
+        else:
+            self._proxy_server = f"{self.scheme}://{self.host}:{self.port}"
+
+    @property
+    def proxy_server(self) -> str:
+        """Return the local proxy address exposed to the browser."""
+        return self._proxy_server
+
+    async def start(self) -> None:
+        """Start the local authenticated proxy forwarder."""
+        if self.server is not None:
+            return
+
+        self.server = await asyncio.start_server(
+            self.handle_request,
+            host=self.host,
+            port=self.port,
+        )
+        await self.server.start_serving()
+        debug_logger.log_info(
+            "proxy_forwarder",
+            "start",
+            f"Started {self.scheme} forwarder on {self.proxy_server}",
+            {"upstream_host": self.fw_host, "upstream_port": self.fw_port},
+        )
+
+    async def close(self) -> None:
+        """Stop the local authenticated proxy forwarder."""
+        if self.server is None:
+            return
+
+        self.server.close()
+        await self.server.wait_closed()
+        self.server = None
+        debug_logger.log_info(
+            "proxy_forwarder",
+            "close",
+            f"Stopped forwarder on {self.proxy_server}",
+        )
+
+    async def handle_request(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        """
+        Route an incoming local proxy connection to the scheme-specific handler.
+
+        Args:
+            reader (asyncio.StreamReader): Local client reader.
+            writer (asyncio.StreamWriter): Local client writer.
+        """
+        try:
+            if self.scheme.startswith("socks"):
+                await self._handle_socks_request(reader, writer)
+                return
+
+            if self.scheme.startswith("http"):
+                await self._handle_http_request(reader, writer)
+                return
+
+            raise ValueError(f"Unsupported proxy scheme: {self.scheme}")
+        except Exception as error:
+            debug_logger.log_error(
+                "proxy_forwarder",
+                "handle_request",
+                error,
+                {"scheme": self.scheme},
+            )
+            await self._close_writer(writer)
+
+    async def _handle_http_request(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        """
+        Forward an HTTP CONNECT tunnel through an authenticated upstream HTTP proxy.
+
+        Args:
+            reader (asyncio.StreamReader): Local client reader.
+            writer (asyncio.StreamWriter): Local client writer.
+        """
+        max_line_length = 8192
+        request_timeout = 5.0
+        upstream_connect_timeout = 30.0
+        remote_writer: Optional[asyncio.StreamWriter] = None
+        pipe_tasks: list[asyncio.Task] = []
+        header_lines: list[bytes] = []
+
+        try:
+            request_line = await asyncio.wait_for(
+                reader.readline(),
+                timeout=request_timeout,
+            )
+            if not request_line:
+                await self._close_writer(writer)
+                return
+            if len(request_line) > max_line_length:
+                await self._write_and_close(
+                    writer,
+                    b"HTTP/1.1 431 Request Header Fields Too Large\r\n\r\n",
+                )
+                return
+
+            request_line_text = request_line.decode("utf-8", errors="ignore")
+            parts = request_line_text.split()
+            if len(parts) < 3:
+                await self._write_and_close(writer, b"HTTP/1.1 400 Bad Request\r\n\r\n")
+                return
+
+            method = parts[0].upper()
+            target_host_port = parts[1]
+            if method == "CONNECT":
+                if ":" not in target_host_port:
+                    await self._write_and_close(
+                        writer,
+                        b"HTTP/1.1 400 Bad Request\r\n\r\n",
+                    )
+                    return
+
+                host, port_text = target_host_port.rsplit(":", 1)
+                try:
+                    port = int(port_text)
+                except ValueError as error:
+                    raise ValueError(f"Invalid target port: {target_host_port}") from error
+                if not host or port < 1 or port > 65535:
+                    raise ValueError(f"Invalid target endpoint: {target_host_port}")
+
+            while True:
+                header = await asyncio.wait_for(
+                    reader.readline(),
+                    timeout=request_timeout,
+                )
+                if len(header) > max_line_length:
+                    await self._write_and_close(
+                        writer,
+                        b"HTTP/1.1 431 Request Header Fields Too Large\r\n\r\n",
+                    )
+                    return
+                if not header or header in {b"\r\n", b"\n"}:
+                    break
+                header_lines.append(header)
+
+            connection_args = {"host": self.fw_host, "port": self.fw_port}
+            if self.use_ssl:
+                connection_args["ssl"] = self.ssl_context or ssl.create_default_context()
+
+            remote_reader, remote_writer = await asyncio.wait_for(
+                asyncio.open_connection(**connection_args),
+                timeout=upstream_connect_timeout,
+            )
+
+            credentials = f"{self.username}:{self.password}"
+            encoded_credentials = base64.b64encode(credentials.encode()).decode("ascii")
+            remote_writer.write(request_line)
+            for header in header_lines:
+                header_text = header.decode("utf-8", errors="ignore").lower()
+                if header_text.startswith("proxy-authorization:"):
+                    continue
+                remote_writer.write(header)
+            remote_writer.write(
+                f"Proxy-Authorization: Basic {encoded_credentials}\r\n".encode()
+            )
+            if method == "CONNECT":
+                remote_writer.write(b"Proxy-Connection: Keep-Alive\r\n")
+            remote_writer.write(b"\r\n")
+            await remote_writer.drain()
+
+            if method == "CONNECT":
+                response_line = await asyncio.wait_for(
+                    remote_reader.readline(),
+                    timeout=request_timeout,
+                )
+                if not response_line:
+                    await self._write_and_close(
+                        writer,
+                        b"HTTP/1.1 502 Bad Gateway\r\n\r\n",
+                    )
+                    return
+
+                while True:
+                    header = await asyncio.wait_for(
+                        remote_reader.readline(),
+                        timeout=request_timeout,
+                    )
+                    if not header or header in {b"\r\n", b"\n"}:
+                        break
+
+                response_text = response_line.decode("utf-8", errors="ignore")
+                if "200" not in response_text:
+                    await self._write_and_close(
+                        writer,
+                        b"HTTP/1.1 502 Bad Gateway\r\nContent-Type: text/plain\r\n\r\n"
+                        b"Upstream proxy rejected the connection\r\n",
+                    )
+                    return
+
+                writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+                await writer.drain()
+
+            event = asyncio.Event()
+            pipe_tasks = [
+                asyncio.create_task(self.pipe(remote_reader, writer, event)),
+                asyncio.create_task(self.pipe(reader, remote_writer, event)),
+            ]
+            await asyncio.gather(*pipe_tasks)
+        except asyncio.TimeoutError:
+            await self._write_and_close(writer, b"HTTP/1.1 504 Gateway Timeout\r\n\r\n")
+        except Exception:
+            raise
+        finally:
+            for task in pipe_tasks:
+                if not task.done():
+                    task.cancel()
+            if pipe_tasks:
+                await asyncio.gather(*pipe_tasks, return_exceptions=True)
+            if remote_writer is not None:
+                await self._close_writer(remote_writer)
+            await self._close_writer(writer)
+
+    async def _handle_socks_request(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        """
+        Forward a SOCKS5 tunnel through an authenticated upstream SOCKS proxy.
+
+        Args:
+            reader (asyncio.StreamReader): Local client reader.
+            writer (asyncio.StreamWriter): Local client writer.
+        """
+        atyp_ipv4 = 0x01
+        atyp_dns = 0x03
+        atyp_ipv6 = 0x04
+        remote_writer: Optional[asyncio.StreamWriter] = None
+
+        async def read_struct(
+            stream: asyncio.StreamReader,
+            fmt: str,
+        ) -> tuple:
+            """Read and unpack an exact struct payload from a stream."""
+            size = calcsize(fmt)
+            data = await stream.readexactly(size)
+            try:
+                return unpack(fmt, data)
+            except struct_error as error:
+                raise ValueError(f"Invalid SOCKS packet for format {fmt}") from error
+
+        try:
+            version, num_methods = await read_struct(reader, "!BB")
+            await reader.readexactly(num_methods)
+            writer.write(pack("!BB", version, 0))
+            await writer.drain()
+
+            version, cmd, reserved, atyp = await read_struct(reader, "!BBBB")
+
+            if atyp == atyp_ipv4:
+                address_payload = await reader.readexactly(4)
+            elif atyp == atyp_ipv6:
+                address_payload = await reader.readexactly(16)
+            elif atyp == atyp_dns:
+                hostname_length = (await read_struct(reader, "!B"))[0]
+                hostname = await reader.readexactly(hostname_length)
+                address_payload = pack("!B", hostname_length) + hostname
+            else:
+                raise ValueError(f"Unsupported SOCKS address type: {atyp}")
+
+            port_payload = await reader.readexactly(2)
+
+            remote_reader, remote_writer = await asyncio.open_connection(
+                host=self.fw_host,
+                port=self.fw_port,
+            )
+
+            remote_writer.write(pack("!BBB", version, 1, 2))
+            await remote_writer.drain()
+            _, auth_method = await read_struct(remote_reader, "!BB")
+
+            if auth_method == 2:
+                auth_ticket = pack(
+                    f"!BB{len(self.username)}sB{len(self.password)}s",
+                    1,
+                    len(self.username),
+                    self.username.encode(),
+                    len(self.password),
+                    self.password.encode(),
+                )
+                remote_writer.write(auth_ticket)
+                await remote_writer.drain()
+                _, auth_result = await read_struct(remote_reader, "!BB")
+                if auth_result != 0:
+                    raise ValueError(
+                        f"SOCKS upstream authentication failed: {auth_result}"
+                    )
+
+            remote_writer.write(pack("!BBBB", version, cmd, reserved, atyp))
+            remote_writer.write(address_payload)
+            remote_writer.write(port_payload)
+            await remote_writer.drain()
+
+            event = asyncio.Event()
+            await asyncio.gather(
+                self.pipe(remote_reader, writer, event),
+                self.pipe(reader, remote_writer, event),
+            )
+        finally:
+            if remote_writer is not None:
+                await self._close_writer(remote_writer)
+            await self._close_writer(writer)
+
+    @staticmethod
+    async def pipe(
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        event: asyncio.Event,
+    ) -> None:
+        """
+        Relay bytes between two streams until either side closes.
+
+        Args:
+            reader (asyncio.StreamReader): Source stream.
+            writer (asyncio.StreamWriter): Destination stream.
+            event (asyncio.Event): Shared completion signal.
+        """
+        while not event.is_set():
+            try:
+                data = await asyncio.wait_for(reader.read(2**16), 1)
+                if not data:
+                    break
+                writer.write(data)
+                await writer.drain()
+            except asyncio.TimeoutError:
+                continue
+            except Exception:
+                break
+        event.set()
+
+    @staticmethod
+    async def _write_and_close(
+        writer: asyncio.StreamWriter,
+        payload: bytes,
+    ) -> None:
+        """
+        Write a terminal response and close a stream.
+
+        Args:
+            writer (asyncio.StreamWriter): Stream writer to close.
+            payload (bytes): Response payload to write before closing.
+        """
+        writer.write(payload)
+        await writer.drain()
+        await AuthenticatedProxyForwarder._close_writer(writer)
+
+    @staticmethod
+    async def _close_writer(writer: asyncio.StreamWriter) -> None:
+        """
+        Close a stream writer if it is still open.
+
+        Args:
+            writer (asyncio.StreamWriter): Stream writer to close.
+        """
+        if writer.is_closing():
+            return
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except Exception:
+            pass

--- a/src/proxy_utils.py
+++ b/src/proxy_utils.py
@@ -43,11 +43,20 @@ def parse_proxy_config(proxy_url: str) -> ProxyConfig:
     hostname = parsed.hostname
     if not hostname:
         raise ProxyConfigError(f"Invalid proxy URL (missing hostname): {raw}")
+    if parsed.port is None:
+        raise ProxyConfigError(f"Invalid proxy URL (missing port): {raw}")
+    if parsed.username is not None and parsed.password is None:
+        raise ProxyConfigError(
+            f"Invalid proxy URL (username requires password): {raw}"
+        )
+    if parsed.password is not None and parsed.username is None:
+        raise ProxyConfigError(
+            f"Invalid proxy URL (password requires username): {raw}"
+        )
 
     host = _format_host(hostname)
     netloc = host
-    if parsed.port is not None:
-        netloc = f"{host}:{parsed.port}"
+    netloc = f"{host}:{parsed.port}"
 
     scheme = parsed.scheme or "http"
     server = urlunsplit((scheme, netloc, "", "", ""))

--- a/src/server.py
+++ b/src/server.py
@@ -158,7 +158,7 @@ async def spawn_browser(
         viewport_height (int): Viewport height in pixels.
         proxy (Optional[str]): Proxy server URL.
         browser_args (List[str]): Additional browser launch args.
-        timezone_id (Optional[str]): IANA timezone ID for browser spawn TZ.
+        timezone_id (Optional[str]): IANA timezone ID applied via CDP timezone override.
         block_resources (List[str]): List of resource types to block (e.g., ['image', 'font', 'stylesheet']).
         extra_headers (Dict[str, str]): Additional HTTP headers.
         user_data_dir (Optional[str]): Path to user data directory for persistent sessions.


### PR DESCRIPTION
This PR makes spawn options first-class so MCP clients can reliably control Chrome launch + timezone without client-side fallback logic.

Changes
- Add `browser_args` (List[str]) + `timezone_id` (IANA TZ) to `spawn_browser` tool + `BrowserOptions`.
- Wire `browser_args` into `uc.Config(browser_args=...)` (still merged with required sandbox args).
- Apply `timezone_id` by temporarily setting `TZ` + `tzset()` during spawn.
- Plumb `proxy` through to an explicit `--proxy-server=...` launch arg and handle authenticated proxies via Fetch `AuthRequired`.
- Return `spawn_diagnostics` (redacted effective args, proxy server, tz, sandbox/headless, user_data_dir).
- Fix section disable flags by unregistering tools after CLI/env parsing (so `--disable-cdp-functions` actually removes cdp tools).

Notes
- Proxy auth handling avoids clobbering existing Fetch `RequestPaused` handlers; it only installs its own continuation handler if dynamic hook interception fails.
- Added an optional env/flag helper (`XPOOL_SAFE_MODE` / `--xpool-safe`) to disable cdp-functions early; happy to rename/remove if you prefer a generic name.