### PR TITLE
fix: missing 'requests' dep + cwd-relative mkdir crash on Claude Desktop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "strbuilder==1.1.3",
     "psutil==7.0.0",
     "pillow==11.3.0",
+    "requests==2.33.1",
     "uvicorn[standard]==0.35.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ strbuilder==1.1.3
 uvicorn[standard]==0.35.0
 psutil==7.0.0
 pillow==11.3.0
+requests>=2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ strbuilder==1.1.3
 uvicorn[standard]==0.35.0
 psutil==7.0.0
 pillow==11.3.0
-requests>=2.31.0
+requests==2.33.1

--- a/src/file_based_element_cloner.py
+++ b/src/file_based_element_cloner.py
@@ -21,15 +21,20 @@ from element_cloner import element_cloner
 class FileBasedElementCloner:
     """Element cloner that saves data to files and returns file paths."""
 
-    def __init__(self, output_dir: str = "element_clones"):
+    def __init__(self, output_dir: Optional[str] = None):
         """
         Initialize with output directory for clone files.
 
         Args:
-            output_dir (str): Directory to save clone files.
+            output_dir (str | None): Directory to save clone files.
+                Defaults to <project_root>/element_clones (absolute path,
+                avoids cwd-dependent failures when launched from Claude Desktop).
         """
-        self.output_dir = Path(output_dir)
-        self.output_dir.mkdir(exist_ok=True)
+        if output_dir is None:
+            self.output_dir = Path(__file__).resolve().parent.parent / "element_clones"
+        else:
+            self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
         self.comprehensive_cloner = ComprehensiveElementCloner()
     
     def _safe_process_framework_handlers(self, framework_handlers):

--- a/src/file_based_element_cloner.py
+++ b/src/file_based_element_cloner.py
@@ -1,18 +1,17 @@
 import asyncio
 import json
-import os
 import sys
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Any, Optional
+from typing import Any, Dict, List, Optional
 
 try:
     from .debug_logger import debug_logger
 except ImportError:
     from debug_logger import debug_logger
 
-project_root = Path(__file__).parent.parent
+project_root = Path(__file__).resolve().parent.parent
 sys.path.append(str(project_root))
 
 from comprehensive_element_cloner import ComprehensiveElementCloner
@@ -26,9 +25,9 @@ class FileBasedElementCloner:
         Initialize with output directory for clone files.
 
         Args:
-            output_dir (str | None): Directory to save clone files.
+            output_dir (Optional[str]): Directory to save clone files.
                 Defaults to <project_root>/element_clones (absolute path,
-                avoids cwd-dependent failures when launched from Claude Desktop).
+                avoids startup failures when the host process uses a read-only cwd).
         """
         if output_dir is None:
             self.output_dir = Path(__file__).resolve().parent.parent / "element_clones"

--- a/src/response_handler.py
+++ b/src/response_handler.py
@@ -24,7 +24,7 @@ class ResponseHandler:
             self.clone_dir = Path(__file__).parent.parent / "element_clones"
         else:
             self.clone_dir = Path(clone_dir)
-        self.clone_dir.mkdir(exist_ok=True)
+        self.clone_dir.mkdir(parents=True, exist_ok=True)
     
     def estimate_tokens(self, data: Any) -> int:
         """

--- a/src/response_handler.py
+++ b/src/response_handler.py
@@ -1,27 +1,26 @@
 """Response handler for managing large responses and automatic file-based fallbacks."""
 
 import json
-import os
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional
 
 
 class ResponseHandler:
     """Handle large responses by automatically falling back to file-based storage."""
     
-    def __init__(self, max_tokens: int = 20000, clone_dir: str = None):
+    def __init__(self, max_tokens: int = 20000, clone_dir: Optional[str] = None):
         """
         Initialize the response handler.
-        
+
         Args:
-            max_tokens: Maximum tokens before falling back to file storage
-            clone_dir: Directory to store large response files
+            max_tokens (int): Maximum token estimate before falling back to file storage.
+            clone_dir (Optional[str]): Directory to store large response files.
         """
         self.max_tokens = max_tokens
         if clone_dir is None:
-            self.clone_dir = Path(__file__).parent.parent / "element_clones"
+            self.clone_dir = Path(__file__).resolve().parent.parent / "element_clones"
         else:
             self.clone_dir = Path(clone_dir)
         self.clone_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
markdown## Problem

When launched as an MCP server from Claude Desktop, `stealth-browser-mcp` fails to start with two errors:

### 1. Missing `requests` dependency
File ".../src/element_cloner.py", line 9, in <module>
import requests
ModuleNotFoundError: No module named 'requests'

`src/element_cloner.py` imports `requests` but it's not in `requirements.txt` / `pyproject.toml`. A fresh `pip install -r requirements.txt` produces a venv that crashes on import.

### 2. cwd-relative `mkdir` crashes when launched by Claude Desktop
File ".../src/file_based_element_cloner.py", line 32, in init
self.output_dir.mkdir(exist_ok=True)
OSError: [Errno 30] Read-only file system: 'element_clones'

`FileBasedElementCloner.__init__` defaulted `output_dir` to the **relative** path `"element_clones"`. Claude Desktop launches MCP servers from the macOS app bundle (read-only cwd), so `mkdir` fails before any tools register.

## Fix

1. **`requirements.txt`** — add `requests>=2.31.0`
2. **`src/file_based_element_cloner.py`** — default `output_dir` to absolute `Path(__file__).resolve().parent.parent / "element_clones"`. Type-hint `Optional[str]`. Add `parents=True` to mkdir.
3. **`src/response_handler.py`** — add `parents=True` to its mkdir for parity.

Behavior unchanged when `output_dir` / `clone_dir` is supplied explicitly — only the default kwarg value is now absolute.

## Test plan

After these changes + `pip install -r requirements.txt` into a fresh venv, Claude Desktop launches the server cleanly and exposes all 19 tools (`spawn_browser`, `navigate`, `click_element`, `type_text`, `take_screenshot`, …).

Repro env: macOS arm64, Python 3.13 (Homebrew), `venv/bin/python src/server.py --minimal`.


