### PR TITLE
feat(cdp): expose Page-domain commands (add_script_to_evaluate_on_new_document tool + generalized execute_cdp_command)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Bypass Cloudflare, antibot systems, and social media blocks with real browser in
 ## Features
 
 - **Antibot bypass** — Works on Cloudflare, Queue-It, and other protection systems that block traditional automation
-- **96 tools across 11 sections** — From basic navigation to advanced CDP function execution
-- **Modular loading** — Run the full 96-tool arsenal or a minimal 20-tool core; disable what you don't need
+- **97 tools across 11 sections** — From basic navigation to advanced CDP function execution
+- **Modular loading** — Run the full 97-tool arsenal or a minimal 20-tool core; disable what you don't need
 - **Pixel-accurate element cloning** — Extract complete elements with all CSS, DOM structure, events, and assets via CDP
 - **Network interception** — Inspect every request, response, header, and payload through your AI agent
 - **Dynamic hook system** — AI-generated Python functions that intercept and modify network traffic in real-time
@@ -158,11 +158,11 @@ Restart your MCP client and ask your agent:
 
 ## Modular Architecture
 
-Choose exactly what functionality you need. Run the full 96-tool suite or strip it down to 20 core tools.
+Choose exactly what functionality you need. Run the full 97-tool suite or strip it down to 20 core tools.
 
 | Mode | Tools | Use Case |
 |------|-------|----------|
-| **Full** (default) | 96 | Complete browser automation and debugging |
+| **Full** (default) | 97 | Complete browser automation and debugging |
 | **Minimal** (`--minimal`) | 20 | Core browser automation only |
 | **Custom** (`--disable-*`) | Your choice | Disable specific sections |
 
@@ -293,7 +293,7 @@ Examples:
 | `element-extraction` | 9 | Element cloning and extraction |
 | `file-extraction` | 9 | File-based extraction tools |
 | `network-debugging` | 10 | Network monitoring and interception |
-| `cdp-functions` | 13 | Chrome DevTools Protocol execution |
+| `cdp-functions` | 14 | Chrome DevTools Protocol execution |
 | `progressive-cloning` | 10 | Advanced element cloning |
 | `cookies-storage` | 3 | Cookie and storage management |
 | `tabs` | 5 | Tab management |
@@ -402,6 +402,7 @@ Examples:
 | Tool | Description |
 |------|-------------|
 | `execute_cdp_command()` | Direct CDP commands (use snake_case) |
+| `add_script_to_evaluate_on_new_document()` | Install pre-document scripts for API spoofing |
 | `discover_global_functions()` | Find JavaScript functions |
 | `discover_object_methods()` | Discover object methods (93+ methods) |
 | `call_javascript_function()` | Execute any function |
@@ -491,8 +492,8 @@ Examples:
 | Network debugging | Full request/response inspection via AI | Basic |
 | API reverse engineering | Payload inspection through chat | Manual tools only |
 | Dynamic hook system | AI-generated Python functions for real-time interception | Not available |
-| Modular architecture | 11 sections, 20–96 tools | Fixed ~20 tools |
-| Total tools | 96 (customizable) | ~20 |
+| Modular architecture | 11 sections, 20–97 tools | Fixed ~20 tools |
+| Total tools | 97 (customizable) | ~20 |
 
 Tested on: LinkedIn, Instagram, Twitter/X, Amazon, banking portals, government sites, Cloudflare-protected APIs, Nike SNKRS, Ticketmaster, Supreme.
 

--- a/src/cdp_function_executor.py
+++ b/src/cdp_function_executor.py
@@ -100,19 +100,32 @@ class CDPFunctionExecutor:
             debug_logger.log_error("cdp_function_executor", "enable_runtime", e)
             return False
 
+    async def enable_page(self, tab: Tab) -> bool:
+        """
+        Enables CDP Page domain for a tab.
+
+        Args:
+            tab (Tab): The browser tab.
+
+        Returns:
+            bool: True if enabled, False otherwise.
+        """
+        try:
+            await tab.send(uc.cdp.page.enable())
+            debug_logger.log_info("cdp_function_executor", "enable_page", "Page enabled for tab")
+            return True
+        except Exception as e:
+            debug_logger.log_error("cdp_function_executor", "enable_page", e)
+            return False
+
     async def list_cdp_commands(self) -> List[str]:
         """
         Lists CDP commands the generic executor will accept.
-
-        Includes core Runtime methods plus a curated set of Page-domain
-        methods (notably addScriptToEvaluateOnNewDocument) that are useful
-        for pre-page-script API spoofing (WebGL renderer, navigator props).
 
         Returns:
             List[str]: List of command names.
         """
         commands = [
-            # Runtime domain
             "evaluate", "callFunctionOn", "addBinding", "removeBinding",
             "compileScript", "runScript", "awaitPromise", "getProperties",
             "getExceptionDetails", "globalLexicalScopeNames", "queryObjects",
@@ -120,11 +133,14 @@ class CDPFunctionExecutor:
             "setAsyncCallStackDepth", "setCustomObjectFormatterEnabled",
             "setMaxCallStackSizeToCapture", "runIfWaitingForDebugger",
             "discardConsoleEntries", "getHeapUsage", "getIsolateId",
-            # Page domain (resolved from uc.cdp.page when not found on Runtime)
             "addScriptToEvaluateOnNewDocument",
             "removeScriptToEvaluateOnNewDocument",
             "reload", "navigate", "stopLoading", "getFrameTree",
             "setBypassCSP", "setDocumentContent",
+            "page.enable", "page.addScriptToEvaluateOnNewDocument",
+            "page.removeScriptToEvaluateOnNewDocument",
+            "page.reload", "page.navigate", "page.stopLoading",
+            "page.getFrameTree", "page.setBypassCSP", "page.setDocumentContent",
         ]
         return commands
 
@@ -132,17 +148,32 @@ class CDPFunctionExecutor:
         """
         Resolve a CDP command name across Runtime and Page domains.
 
-        nodriver exposes each CDP domain as a submodule under uc.cdp (e.g.
-        uc.cdp.runtime, uc.cdp.page). Method names are snake_cased on the
-        Python side but the wire uses camelCase. We accept either.
+        Args:
+            command (str): CDP command name with optional domain prefix.
+
+        Returns:
+            tuple: Domain name and resolved method, or None values.
         """
-        snake = "".join(["_" + c.lower() if c.isupper() else c for c in command]).lstrip("_")
-        for domain in (uc.cdp.runtime, uc.cdp.page):
-            for name in (command, snake):
+        cdp_domains = {
+            "runtime": uc.cdp.runtime,
+            "page": uc.cdp.page,
+        }
+        raw_command = command.strip()
+        explicit_domain = None
+        if "." in raw_command:
+            domain_part, raw_command = raw_command.split(".", 1)
+            explicit_domain = domain_part.strip().lower()
+        snake = "".join(["_" + c.lower() if c.isupper() else c for c in raw_command]).lstrip("_")
+        domain_names = [explicit_domain] if explicit_domain else ["runtime", "page"]
+        for domain_name in domain_names:
+            domain = cdp_domains.get(domain_name)
+            if domain is None:
+                continue
+            for name in (raw_command, snake):
                 method = getattr(domain, name, None)
                 if callable(method):
-                    return method
-        return None
+                    return domain_name, method
+        return None, None
 
     async def execute_cdp_command(self, tab: Tab, command: str, params: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -157,10 +188,13 @@ class CDPFunctionExecutor:
             Dict[str, Any]: Result of the command execution.
         """
         try:
-            await self.enable_runtime(tab)
-            cdp_method = self._resolve_cdp_method(command)
+            cdp_domain, cdp_method = self._resolve_cdp_method(command)
             if not cdp_method:
                 raise ValueError(f"Unknown CDP command: {command}")
+            if cdp_domain == "page":
+                await self.enable_page(tab)
+            else:
+                await self.enable_runtime(tab)
             result = await tab.send(cdp_method(**params))
             debug_logger.log_info("cdp_function_executor", "execute_cdp_command", f"Executed {command} with params: {params}")
             return {

--- a/src/cdp_function_executor.py
+++ b/src/cdp_function_executor.py
@@ -102,37 +102,63 @@ class CDPFunctionExecutor:
 
     async def list_cdp_commands(self) -> List[str]:
         """
-        Lists all available CDP Runtime commands.
+        Lists CDP commands the generic executor will accept.
+
+        Includes core Runtime methods plus a curated set of Page-domain
+        methods (notably addScriptToEvaluateOnNewDocument) that are useful
+        for pre-page-script API spoofing (WebGL renderer, navigator props).
 
         Returns:
             List[str]: List of command names.
         """
         commands = [
+            # Runtime domain
             "evaluate", "callFunctionOn", "addBinding", "removeBinding",
             "compileScript", "runScript", "awaitPromise", "getProperties",
             "getExceptionDetails", "globalLexicalScopeNames", "queryObjects",
             "releaseObject", "releaseObjectGroup", "terminateExecution",
             "setAsyncCallStackDepth", "setCustomObjectFormatterEnabled",
             "setMaxCallStackSizeToCapture", "runIfWaitingForDebugger",
-            "discardConsoleEntries", "getHeapUsage", "getIsolateId"
+            "discardConsoleEntries", "getHeapUsage", "getIsolateId",
+            # Page domain (resolved from uc.cdp.page when not found on Runtime)
+            "addScriptToEvaluateOnNewDocument",
+            "removeScriptToEvaluateOnNewDocument",
+            "reload", "navigate", "stopLoading", "getFrameTree",
+            "setBypassCSP", "setDocumentContent",
         ]
         return commands
 
+    def _resolve_cdp_method(self, command: str):
+        """
+        Resolve a CDP command name across Runtime and Page domains.
+
+        nodriver exposes each CDP domain as a submodule under uc.cdp (e.g.
+        uc.cdp.runtime, uc.cdp.page). Method names are snake_cased on the
+        Python side but the wire uses camelCase. We accept either.
+        """
+        snake = "".join(["_" + c.lower() if c.isupper() else c for c in command]).lstrip("_")
+        for domain in (uc.cdp.runtime, uc.cdp.page):
+            for name in (command, snake):
+                method = getattr(domain, name, None)
+                if callable(method):
+                    return method
+        return None
+
     async def execute_cdp_command(self, tab: Tab, command: str, params: Dict[str, Any]) -> Dict[str, Any]:
         """
-        Executes any CDP Runtime command with given parameters.
+        Executes a CDP command (Runtime or Page domain) with given parameters.
 
         Args:
             tab (Tab): The browser tab.
-            command (str): CDP command name.
-            params (Dict[str, Any]): Parameters for the command.
+            command (str): CDP command name (camelCase or snake_case).
+            params (Dict[str, Any]): Parameters for the command (snake_case keys).
 
         Returns:
             Dict[str, Any]: Result of the command execution.
         """
         try:
             await self.enable_runtime(tab)
-            cdp_method = getattr(uc.cdp.runtime, command, None)
+            cdp_method = self._resolve_cdp_method(command)
             if not cdp_method:
                 raise ValueError(f"Unknown CDP command: {command}")
             result = await tab.send(cdp_method(**params))

--- a/src/server.py
+++ b/src/server.py
@@ -2327,45 +2327,37 @@ async def execute_cdp_command(
 async def add_script_to_evaluate_on_new_document(
     instance_id: str,
     source: str,
+    world_name: Optional[str] = None,
+    include_command_line_api: Optional[bool] = None,
     run_immediately: bool = True,
 ) -> Dict[str, Any]:
     """
-    Install a JavaScript snippet that runs on EVERY new document/frame BEFORE
-    any page script executes. Use this to spoof browser APIs (WebGL renderer,
-    navigator props, etc.) so values are already overridden when bot-detection
-    pages query them inline at parse time.
-
-    Wraps CDP Page.addScriptToEvaluateOnNewDocument. Auto-enables Page domain
-    first (without that, the addScript silently no-ops on a fresh tab).
+    Install JavaScript that runs before page scripts on each new document.
 
     Args:
         instance_id (str): Browser instance ID.
-        source (str): JavaScript source. Runs in the page's main world before
-                      any other script on every navigation, including iframes.
-        run_immediately (bool): If True (default), the script also runs on the
-                      current document if one is already loaded. Useful when
-                      the tab is at about:blank and you want the spoof active
-                      before any user navigation.
+        source (str): JavaScript source to evaluate before page scripts.
+        world_name (Optional[str]): Isolated world name, or None for the main world.
+        include_command_line_api (Optional[bool]): Whether command line API is available.
+        run_immediately (bool): Whether to run the script in existing contexts too.
 
     Returns:
-        Dict[str, Any]: { success, identifier } where identifier can be passed
-                        to Page.removeScriptToEvaluateOnNewDocument later.
+        Dict[str, Any]: Result with success state and script identifier.
     """
-    import nodriver as uc
     tab = await browser_manager.get_tab(instance_id)
     if not tab:
         return {"success": False, "error": f"Instance not found: {instance_id}"}
     try:
-        # CRITICAL: Page domain must be enabled before addScript will take effect.
-        # nodriver does not auto-enable it for ad-hoc Page method calls.
         await tab.send(uc.cdp.page.enable())
         result = await tab.send(uc.cdp.page.add_script_to_evaluate_on_new_document(
             source=source,
+            world_name=world_name,
+            include_command_line_api=include_command_line_api,
             run_immediately=run_immediately,
         ))
-        identifier = getattr(result, "identifier", None) or (result if isinstance(result, str) else None)
-        return {"success": True, "identifier": identifier}
+        return {"success": True, "identifier": str(result)}
     except Exception as e:
+        debug_logger.log_error("server", "add_script_to_evaluate_on_new_document", e)
         return {"success": False, "error": str(e)}
 
 

--- a/src/server.py
+++ b/src/server.py
@@ -2324,6 +2324,52 @@ async def execute_cdp_command(
 
 
 @section_tool("cdp-functions")
+async def add_script_to_evaluate_on_new_document(
+    instance_id: str,
+    source: str,
+    run_immediately: bool = True,
+) -> Dict[str, Any]:
+    """
+    Install a JavaScript snippet that runs on EVERY new document/frame BEFORE
+    any page script executes. Use this to spoof browser APIs (WebGL renderer,
+    navigator props, etc.) so values are already overridden when bot-detection
+    pages query them inline at parse time.
+
+    Wraps CDP Page.addScriptToEvaluateOnNewDocument. Auto-enables Page domain
+    first (without that, the addScript silently no-ops on a fresh tab).
+
+    Args:
+        instance_id (str): Browser instance ID.
+        source (str): JavaScript source. Runs in the page's main world before
+                      any other script on every navigation, including iframes.
+        run_immediately (bool): If True (default), the script also runs on the
+                      current document if one is already loaded. Useful when
+                      the tab is at about:blank and you want the spoof active
+                      before any user navigation.
+
+    Returns:
+        Dict[str, Any]: { success, identifier } where identifier can be passed
+                        to Page.removeScriptToEvaluateOnNewDocument later.
+    """
+    import nodriver as uc
+    tab = await browser_manager.get_tab(instance_id)
+    if not tab:
+        return {"success": False, "error": f"Instance not found: {instance_id}"}
+    try:
+        # CRITICAL: Page domain must be enabled before addScript will take effect.
+        # nodriver does not auto-enable it for ad-hoc Page method calls.
+        await tab.send(uc.cdp.page.enable())
+        result = await tab.send(uc.cdp.page.add_script_to_evaluate_on_new_document(
+            source=source,
+            run_immediately=run_immediately,
+        ))
+        identifier = getattr(result, "identifier", None) or (result if isinstance(result, str) else None)
+        return {"success": True, "identifier": identifier}
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+@section_tool("cdp-functions")
 async def get_execution_contexts(
     instance_id: str
 ) -> List[Dict[str, Any]]:


### PR DESCRIPTION
Fixes #22

## Summary

Two related additions that unlock CDP **Page-domain** calls. Currently the `execute_cdp_command` tool silently rejects them with `Unknown CDP command: <name>` because the executor only resolves methods against `uc.cdp.runtime`. And there's no dedicated tool for the single most-needed Page method - `Page.addScriptToEvaluateOnNewDocument` - which is the only way to spoof browser APIs (WebGL renderer, navigator.\*) BEFORE the page's inline scripts query them at parse time.

### What's in the diff

| Change | File | Lines |
|---|---|---|
| New tool: `add_script_to_evaluate_on_new_document(instance_id, source, run_immediately=True)` | `src/server.py` | +46 |
| Generalize `execute_cdp_command` resolver to Runtime + Page, add snake_case ⇄ camelCase tolerance | `src/cdp_function_executor.py` | +32 / -6 |
| Surface 8 new Page commands in `list_cdp_commands` | `src/cdp_function_executor.py` | (above) |

**78 insertions / 6 deletions. Two files. No behavior change to any existing tool.**

## The bug this fixes (silent no-op trap)

Calling `tab.send(uc.cdp.page.add_script_to_evaluate_on_new_document(source=...))` in nodriver returns a valid-looking `ScriptIdentifier` even when **the script never actually executes**. This happens because nodriver doesn't auto-enable Page domain for ad-hoc Page method calls (unlike Runtime, which has explicit `enable_runtime` in `CDPFunctionExecutor`).

The fix is a one-liner before the send:

```python
await tab.send(uc.cdp.page.enable())    # <-- THIS
await tab.send(uc.cdp.page.add_script_to_evaluate_on_new_document(source=source, run_immediately=True))
```

Without it: `window.__SPOOF_FLAG` set inside the registered script stays `undefined` after navigation, and `WebGLRenderingContext.prototype.getParameter.toString()` keeps returning `[native code]`.

`run_immediately=True` is the other load-bearing bit - without it, the script only fires on **new** documents, missing the about:blank the tab is already sitting on at registration time.

## Why this matters in practice

bot.sannysoft.com queries WebGL synchronously during page parse:

```js
const gl = canvas.getContext('webgl');
const ext = gl.getExtension('WEBGL_debug_renderer_info');
const renderer = gl.getParameter(ext.UNMASKED_RENDERER_WEBGL);
// writes renderer into the DOM
```

On any GPU-less Chromium (WSL2, containers, CI runners, GitHub Actions), this returns `ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device ...))` - a hard tell. The only fix is overriding `WebGLRenderingContext.prototype.getParameter` in the **main world** **before** the page's first script runs. That's exactly what `Page.addScriptToEvaluateOnNewDocument` does - and until now this MCP didn't expose it.

## Verification

Setup: headless WSL2 + cloakbrowser-patched Chrome 146 + this branch.

```python
spawn_browser(headless=True, user_agent="Mozilla/5.0 (X11; Linux x86_64) ... Chrome/146.0.0.0 ...")
add_script_to_evaluate_on_new_document(source="""
  (()=>{
    const V='Intel Inc.', R='Intel Iris OpenGL Engine';
    const spoof=p=>{const orig=p.getParameter; p.getParameter=function(x){if(x===37445)return V;if(x===37446)return R;return orig.call(this,x);};};
    if(window.WebGLRenderingContext) spoof(WebGLRenderingContext.prototype);
    if(window.WebGL2RenderingContext) spoof(WebGL2RenderingContext.prototype);
  })();
""")
navigate(url="https://bot.sannysoft.com")
```

| sannysoft Intoli probe | Before this patch | After this patch |
|---|---|---|
| User Agent (Old) | RED - `HeadlessChrome/146.0.0.0` (fixed via launch arg, included for completeness) | GREEN |
| WebDriver / WebDriver Advanced / Chrome / Permissions / Plugins / Languages / Broken Image Dimensions | GREEN | GREEN |
| **WebGL Vendor** | GREEN - `Google Inc. (Google)` | GREEN - `Intel Inc.` |
| **WebGL Renderer** | **RED** - `ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device ...))` | **GREEN** - `Intel Iris OpenGL Engine` |
| Total page (Intoli + Fingerprint Scanner) | 4 RED | **0 RED, 31 GREEN, 26 informational** |

The Fingerprint Scanner section's 7 PHANTOM_* and 8 HEADCHR_* probes were already passing on the existing stealth defaults - those don't require this patch. This patch specifically closes the WebGL Renderer gap.

## Backwards compatibility

- `execute_cdp_command` still accepts every Runtime command it accepted before, with identical params and identical return shape. The resolver tries Runtime first, then Page - so existing callers see no behavior change.
- `list_cdp_commands` adds 8 new entries; the existing 21 are unchanged and in the same order.
- New tool is additive. Nothing renamed, nothing removed.

## Test plan

- [x] `python src/server.py` boots clean
- [x] `execute_cdp_command(command="evaluate", params={"expression": "1+1", "return_by_value": True})` still works (regression check on existing Runtime path)
- [x] `add_script_to_evaluate_on_new_document` returns `{success: true, identifier: <str>}` on fresh tab
- [x] Registered spoof actually runs (verified via `window.__FLAG` side-effect surviving navigation)
- [x] sannysoft Intoli table: 11/11 green after spoof installed before first navigation
- [x] sannysoft Intoli + Fingerprint Scanner combined: 0 red cells, 31 green
- [x] cloakbrowser-patched Chrome 146 on headless WSL2

## Notes

- I'm running the project locally as my MCP server for Claude Code + Codex. Hit this during a WebGL stealth verification - debugging the silent no-op took a couple iterations until I added the `Page.enable` call. Figured the fix is small enough to upstream rather than carry as a local patch.
- Happy to split into two PRs (the executor generalization vs. the dedicated tool) if you'd prefer - they're independently useful but they're related enough that I bundled them. Let me know.