### PR TITLE
fix: clean up dynamic hook tasks on browser close

### DIFF
--- a/src/browser_manager.py
+++ b/src/browser_manager.py
@@ -412,6 +412,10 @@ class BrowserManager:
             })
 
         except Exception as e:
+            try:
+                await dynamic_hook_system.cleanup_instance(instance_id)
+            except Exception:
+                pass
             if browser is not None:
                 try:
                     await self._stop_browser(browser)
@@ -497,6 +501,8 @@ class BrowserManager:
                 data = self._instances[instance_id]
                 browser = data['browser']
                 instance = data['instance']
+
+                await dynamic_hook_system.cleanup_instance(instance_id)
 
                 try:
                     if hasattr(browser, 'tabs') and browser.tabs:
@@ -611,6 +617,7 @@ class BrowserManager:
                     if instance_id in self._instances:
                         data = self._instances[instance_id]
                         data['instance'].state = BrowserState.CLOSED
+                        dynamic_hook_system.cancel_instance(instance_id)
                         process_cleanup.kill_browser_process(instance_id)
                         process_cleanup.finalize_browser_process(instance_id)
                         process_cleanup.cleanup_deferred_profiles()

--- a/src/dynamic_hook_system.py
+++ b/src/dynamic_hook_system.py
@@ -163,6 +163,8 @@ class DynamicHookSystem:
         self.hooks: Dict[str, DynamicHook] = {}
         self.instance_hooks: Dict[str, List[str]] = {}  # instance_id -> list of hook_ids
         self._lock = asyncio.Lock()
+        self._request_tasks: Dict[str, set[asyncio.Task]] = {}
+        self._interception_handlers: Dict[str, tuple[Any, Callable]] = {}
     
     async def setup_interception(self, tab, instance_id: str):
         """Set up request and response interception for a browser tab."""
@@ -213,10 +215,27 @@ class DynamicHookSystem:
             
             await tab.send(uc.cdp.fetch.enable(patterns=all_patterns))
             
-            tab.add_handler(
-                uc.cdp.fetch.RequestPaused,
-                lambda event: asyncio.create_task(self._on_request_paused(tab, event, instance_id))
-            )
+            def schedule_request(event):
+                task = asyncio.create_task(
+                    self._on_request_paused(tab, event, instance_id)
+                )
+                tasks = self._request_tasks.setdefault(instance_id, set())
+                tasks.add(task)
+                task.add_done_callback(tasks.discard)
+
+            previous = self._interception_handlers.pop(instance_id, None)
+            if previous:
+                previous_tab, previous_handler = previous
+                try:
+                    previous_tab.remove_handler(
+                        uc.cdp.fetch.RequestPaused,
+                        previous_handler,
+                    )
+                except Exception:
+                    pass
+
+            tab.add_handler(uc.cdp.fetch.RequestPaused, schedule_request)
+            self._interception_handlers[instance_id] = (tab, schedule_request)
             
             debug_logger.log_info("dynamic_hook_system", "setup_interception", f"Set up interception for instance {instance_id} with {len(all_patterns)} patterns ({len(request_patterns)} request, {len(response_patterns)} response)")
             
@@ -333,6 +352,34 @@ class DynamicHookSystem:
             except:
                 pass
     
+    def _detach_instance(self, instance_id: str) -> List[asyncio.Task]:
+        """Detach interception and cancel pending request tasks for an instance."""
+        handler_entry = self._interception_handlers.pop(instance_id, None)
+        if handler_entry:
+            tab, handler = handler_entry
+            try:
+                tab.remove_handler(uc.cdp.fetch.RequestPaused, handler)
+            except Exception:
+                pass
+
+        tasks = list(self._request_tasks.pop(instance_id, set()))
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+
+        self.instance_hooks.pop(instance_id, None)
+        return tasks
+
+    async def cleanup_instance(self, instance_id: str) -> None:
+        """Clean up dynamic-hook interception state for a browser instance."""
+        tasks = self._detach_instance(instance_id)
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    def cancel_instance(self, instance_id: str) -> None:
+        """Cancel dynamic-hook work during forced synchronous cleanup."""
+        self._detach_instance(instance_id)
+
     async def create_hook(self, name: str, requirements: Dict[str, Any], function_code: str, 
                          instance_ids: Optional[List[str]] = None, priority: int = 100) -> str:
         """Create a new dynamic hook."""

--- a/tests/test_dynamic_hook_cleanup.py
+++ b/tests/test_dynamic_hook_cleanup.py
@@ -1,0 +1,74 @@
+import asyncio
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+import nodriver as uc
+
+from dynamic_hook_system import DynamicHookSystem
+
+
+class FakeTab:
+    def __init__(self):
+        self.handlers = {}
+
+    async def send(self, command):
+        return None
+
+    def add_handler(self, event_type, handler):
+        self.handlers.setdefault(event_type, []).append(handler)
+
+    def remove_handler(self, event_type, handler=None):
+        if event_type not in self.handlers:
+            return
+        if handler is None:
+            self.handlers.pop(event_type, None)
+            return
+        self.handlers[event_type].remove(handler)
+        if not self.handlers[event_type]:
+            self.handlers.pop(event_type, None)
+
+    def emit(self, event_type, event):
+        for handler in list(self.handlers.get(event_type, [])):
+            handler(event)
+
+
+class DynamicHookCleanupTests(unittest.IsolatedAsyncioTestCase):
+    async def test_cleanup_cancels_request_tasks_and_removes_handler(self):
+        system = DynamicHookSystem()
+        tab = FakeTab()
+        instance_id = "browser-1"
+        started = asyncio.Event()
+        cancelled = asyncio.Event()
+
+        async def pending_request(tab, event, request_instance_id):
+            started.set()
+            try:
+                await asyncio.Future()
+            finally:
+                cancelled.set()
+
+        system._on_request_paused = pending_request
+        system.add_instance(instance_id)
+        await system.setup_interception(tab, instance_id)
+
+        self.assertIn(uc.cdp.fetch.RequestPaused, tab.handlers)
+        tab.emit(uc.cdp.fetch.RequestPaused, object())
+        await asyncio.wait_for(started.wait(), timeout=1)
+
+        request_task = next(iter(system._request_tasks[instance_id]))
+        await system.cleanup_instance(instance_id)
+
+        self.assertTrue(request_task.cancelled())
+        self.assertTrue(cancelled.is_set())
+        self.assertNotIn(uc.cdp.fetch.RequestPaused, tab.handlers)
+        self.assertNotIn(instance_id, system._request_tasks)
+        self.assertNotIn(instance_id, system._interception_handlers)
+        self.assertNotIn(instance_id, system.instance_hooks)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- track per-instance dynamic-hook request tasks instead of leaving them unowned
- unregister request interception handlers and cancel/await pending hook tasks before browser teardown
- clean hook state on spawn failures and forced close timeouts
- add a regression test covering task cancellation and handler cleanup

## Validation
- `python -m py_compile $(git ls-files '*.py')`
- `python -m unittest discover -s tests -v`